### PR TITLE
Fix an issue when window.devicePixelRatio != 1

### DIFF
--- a/src/app/pages/editor/editor/editor.component.ts
+++ b/src/app/pages/editor/editor/editor.component.ts
@@ -167,7 +167,8 @@ export class EditorComponent implements OnInit {
         zip.file(`${nameFiles}_atlas.json`, dataStr);
 
         html2canvas(_$('#output'), {
-            backgroundColor: 'rgba(0, 0, 0, 0)'
+            backgroundColor: 'rgba(0, 0, 0, 0)',
+            scale: 1
         }).then((canvas) => {
             // Generate zip
             zip.file(`${nameFiles}.png`, canvas.toDataURL().replace('data:image/png;base64,', ''), { base64: true });


### PR DESCRIPTION
I used this tool on my MacBook Pro with Retina display. The output PNG is always twice as big as in JSON file. According to the documentation of `HTML2CANVAS`, default value of scale is the browsers device pixel ratio which is 2 in my case. Explicitly passing scale to the function may solve this problem.
Since I'm not familiar with neither your project nor front-end development, you can fix this by your own way.  I would appreciate it if you could update gh-pages for me after fixing this issue.

Reference: https://html2canvas.hertzen.com/configuration